### PR TITLE
Permet l'utilisation de points d'arrêt sur les fichiers TS

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,70 @@ Le TDD suit un cycle particulier, comme vous pouvez voir à l'image plus haut:
   </p>
   </details>
 
+## Support pour déboguage
+
+   <details>
+     <summary>Plus de détails</summary><p>
+
+Ce squelette offre la possibilité de déboguer le code du serveur à l'aide de points d'arrêt placés à l'intérieur des fichiers TypeScript. 
+
+Voici comment il est possible de déboguer le projet à l'aide de différents environnements de développement.
+
+### Déboguage avec Visual Studio Code
+
+VS Code offre la possibilité d'ajouter des configurations d'exécution à l'aide d'un fichier local. Ce fichier doit être nommé <i>launch.json</i> et être placé dans un dossier nommé <i>.vscode</i> à la racine du projet.
+
+On peut utiliser ce fichier afin de créer des configurations d'exécution de déboguage pour le projet. Un exemple de contenu pour ce fichier pourrait être :
+
+```json
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "command": "npm start",
+            "name": "Debug",
+            "request": "launch",
+            "type": "node-terminal"
+        },
+        {
+            "command": "npm run start:watch",
+            "name": "Debug:Watch",
+            "request": "launch",
+            "type": "node-terminal"
+        }
+    ]
+}
+```
+
+Le lien suivant présente les subtilités de l'utilisation du fichier <i>launch.json</i> de VS Code dans le cadre d'un projet NodeJS : https://code.visualstudio.com/docs/nodejs/nodejs-debugging
+
+Les configurations créées dans ce fichier peuvent ensuite être lancées à partir de l'onglet « Run » de la barre de régions à gauche de VS Code.
+
+Alternativement, il est possible d'attacher le débogueur de VS Code à une nouvelle exécution du projet sans avoir à créer un fichier <i>launch.json</i>. Il suffit de se rendre sur le fichier [package.json](./package.json) et de cliquer sur le bouton « Debug » qui apparaît au-dessus de la section « Script ».
+
+Une fois le débogueur attaché par l'une ou l'autre des méthodes présentées ci-dessus, l'exécution du code cessera lors de la rencontre d'un point d'arrêt sur un fichier TypeScript et il sera possible d'inspecter la valeur des variables visibles.
+
+Pour plus d'informations au sujet de l'utilisation des breakpoints dans VS Code, voir https://code.visualstudio.com/docs/editor/debugging#_breakpoints
+
+### Déboguage avec JetBrains WebStorm
+
+Les mêmes instructions présentées dans cette section peuvent être utilisées pour déboguer le projet à partir d'un autre environnement JetBrains (comme IntelliJ) lorsque les plugins nécessaires sont installés.
+
+Dans WebStorm, il est possible de créer une configuration d'exécution à l'aide de la liste défilante à côté du bouton d'exécution « Run ». Pour ce projet, il est nécessaire de créer une configuration de type « npm » et de lui associer la commande « run » ainsi que le script « start » ou « start:watch ».
+
+Le lien suivant présente les subtilités de cette configuration avec plus de détails : https://www.jetbrains.com/help/webstorm/run-debug-configuration-npm.html
+
+Les configurations ainsi créées peuvent ensuite être lancées en mode déboguage en cliquant sur le bouton « Debug » à droite du bouton « Start ».
+
+Alternativement, il est possible d'attacher le débogueur de WebStorm à une nouvelle exécution du projet sans avoir à créer une nouvelle configuration d'exécution. Il suffit de se rendre sur le fichier [package.json](./package.json) et de cliquer sur le bouton en forme de triangle vert à côté des scripts « start » ou « start:watch » et de sélectionner l'option « Debug ».
+
+Une fois le débogueur attaché par l'une ou l'autre des méthodes présentées ci-dessus, l'exécution du code cessera lors de la rencontre d'un point d'arrêt sur un fichier TypeScript et il sera possible d'inspecter la valeur des variables visibles.
+
+Pour plus d'informations au sujet de l'utilisation des breakpoints dans WebStorm, voir https://www.jetbrains.com/help/webstorm/using-breakpoints.html
+
+  </p>
+  </details>
+
 ## Couplage souhaitable entre la couche Présentation et la couche Domaine
 
 Dans un design favorisant la maintenabilité, on évite que la couche Présentation ait la responsabilité de gérer les évènements système (opérations système). Larman présente dans son livre un exemple avec un JFrame (en Java Swing) à la figure F16.24. On l'adapte ici au contexte d'un service Web dans le framework Express (Node.js):

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,6 @@
 const gulp = require('gulp');
 const ts = require('gulp-typescript');
+const sourcemaps = require('gulp-sourcemaps');
 const JSON_FILES = ['src/*.json', 'src/**/*.json'];
 const CSS_FILES = ['public/css/*.css'];
 const JS_FILES = ['public/lib/*.js'];
@@ -8,9 +9,14 @@ const JS_FILES = ['public/lib/*.js'];
 const tsProject = ts.createProject('tsconfig.json');
 
 gulp.task('scripts', () => {
-  const tsResult = tsProject.src()
-  .pipe(tsProject());
-  return tsResult.js.pipe(gulp.dest('dist'));
+  return tsProject.src()
+    .pipe(sourcemaps.init())
+    .pipe(tsProject())
+    .js
+    .pipe(sourcemaps.write('.', {
+      sourceRoot: function(file) { return file.cwd + '/src'; }
+    }))
+    .pipe(gulp.dest('dist'));
 });
 
 gulp.task('watch', function watchSrc() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -387,6 +387,57 @@
                 "minimist": "^1.2.0"
             }
         },
+        "@gulp-sourcemaps/identity-map": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@gulp-sourcemaps/identity-map/-/identity-map-1.0.2.tgz",
+            "integrity": "sha512-ciiioYMLdo16ShmfHBXJBOFm3xPC4AuwO4xeRpFeHz7WK9PYsWCmigagG2XyzZpubK4a3qNKoUBDhbzHfa50LQ==",
+            "dev": true,
+            "requires": {
+                "acorn": "^5.0.3",
+                "css": "^2.2.1",
+                "normalize-path": "^2.1.1",
+                "source-map": "^0.6.0",
+                "through2": "^2.0.3"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "5.7.4",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+                    "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
+                    "dev": true
+                },
+                "normalize-path": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+                    "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+                    "dev": true,
+                    "requires": {
+                        "remove-trailing-separator": "^1.0.1"
+                    }
+                }
+            }
+        },
+        "@gulp-sourcemaps/map-sources": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@gulp-sourcemaps/map-sources/-/map-sources-1.0.0.tgz",
+            "integrity": "sha1-iQrnxdjId/bThIYCFazp1+yUW9o=",
+            "dev": true,
+            "requires": {
+                "normalize-path": "^2.0.1",
+                "through2": "^2.0.3"
+            },
+            "dependencies": {
+                "normalize-path": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+                    "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+                    "dev": true,
+                    "requires": {
+                        "remove-trailing-separator": "^1.0.1"
+                    }
+                }
+            }
+        },
         "@istanbuljs/load-nyc-config": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -1931,6 +1982,16 @@
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
             "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow=="
         },
+        "bindings": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+            "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "file-uri-to-path": "1.0.0"
+            }
+        },
         "body-parser": {
             "version": "1.19.0",
             "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
@@ -2569,6 +2630,18 @@
             "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
             "dev": true
         },
+        "css": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
+            "integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
+            "dev": true,
+            "requires": {
+                "inherits": "^2.0.3",
+                "source-map": "^0.6.1",
+                "source-map-resolve": "^0.5.2",
+                "urix": "^0.1.0"
+            }
+        },
         "cssom": {
             "version": "0.4.4",
             "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
@@ -2628,6 +2701,28 @@
             "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
             "requires": {
                 "ms": "^2.1.1"
+            }
+        },
+        "debug-fabulous": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/debug-fabulous/-/debug-fabulous-1.1.0.tgz",
+            "integrity": "sha512-GZqvGIgKNlUnHUPQhepnUZFIMoi3dgZKQBzKDeL2g7oJF9SNAji/AAu36dusFUas0O+pae74lNeoIPHqXWDkLg==",
+            "dev": true,
+            "requires": {
+                "debug": "3.X",
+                "memoizee": "0.4.X",
+                "object-assign": "4.X"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.2.6",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+                    "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                }
             }
         },
         "decamelize": {
@@ -3036,6 +3131,16 @@
             "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
             "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
         },
+        "event-emitter": {
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+            "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+            "dev": true,
+            "requires": {
+                "d": "1",
+                "es5-ext": "~0.10.14"
+            }
+        },
         "exec-sh": {
             "version": "0.3.4",
             "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.4.tgz",
@@ -3414,6 +3519,13 @@
             "requires": {
                 "bser": "2.1.1"
             }
+        },
+        "file-uri-to-path": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+            "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+            "dev": true,
+            "optional": true
         },
         "filelist": {
             "version": "1.0.1",
@@ -3815,7 +3927,11 @@
                     "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
                     "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
                     "dev": true,
-                    "optional": true
+                    "optional": true,
+                    "requires": {
+                        "bindings": "^1.5.0",
+                        "nan": "^2.12.1"
+                    }
                 },
                 "glob-parent": {
                     "version": "3.1.0",
@@ -4145,6 +4261,39 @@
                         "camelcase": "^3.0.0",
                         "object.assign": "^4.1.0"
                     }
+                }
+            }
+        },
+        "gulp-sourcemaps": {
+            "version": "2.6.5",
+            "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-2.6.5.tgz",
+            "integrity": "sha512-SYLBRzPTew8T5Suh2U8jCSDKY+4NARua4aqjj8HOysBh2tSgT9u4jc1FYirAdPx1akUxxDeK++fqw6Jg0LkQRg==",
+            "dev": true,
+            "requires": {
+                "@gulp-sourcemaps/identity-map": "1.X",
+                "@gulp-sourcemaps/map-sources": "1.X",
+                "acorn": "5.X",
+                "convert-source-map": "1.X",
+                "css": "2.X",
+                "debug-fabulous": "1.X",
+                "detect-newline": "2.X",
+                "graceful-fs": "4.X",
+                "source-map": "~0.6.0",
+                "strip-bom-string": "1.X",
+                "through2": "2.X"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "5.7.4",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+                    "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
+                    "dev": true
+                },
+                "detect-newline": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+                    "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
+                    "dev": true
                 }
             }
         },
@@ -7063,6 +7212,15 @@
             "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
             "dev": true
         },
+        "lru-queue": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
+            "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
+            "dev": true,
+            "requires": {
+                "es5-ext": "~0.10.2"
+            }
+        },
         "make-dir": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -7166,6 +7324,22 @@
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
             "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+        },
+        "memoizee": {
+            "version": "0.4.14",
+            "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.14.tgz",
+            "integrity": "sha512-/SWFvWegAIYAO4NQMpcX+gcra0yEZu4OntmUdrBaWrJncxOqAziGFlHxc7yjKVK2uu3lpPW27P27wkR82wA8mg==",
+            "dev": true,
+            "requires": {
+                "d": "1",
+                "es5-ext": "^0.10.45",
+                "es6-weak-map": "^2.0.2",
+                "event-emitter": "^0.3.5",
+                "is-promise": "^2.1",
+                "lru-queue": "0.1",
+                "next-tick": "1",
+                "timers-ext": "^0.1.5"
+            }
         },
         "merge-descriptors": {
             "version": "1.0.1",
@@ -7414,6 +7588,13 @@
             "resolved": "https://registry.npmjs.org/mute-stdout/-/mute-stdout-1.0.1.tgz",
             "integrity": "sha512-kDcwXR4PS7caBpuRYYBUz9iVixUk3anO3f5OYFiIPwK/20vCzKCHyKoulbiDY1S53zD2bxUpxN/IJ+TnXjfvxg==",
             "dev": true
+        },
+        "nan": {
+            "version": "2.14.2",
+            "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+            "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+            "dev": true,
+            "optional": true
         },
         "nanomatch": {
             "version": "1.2.13",
@@ -9425,6 +9606,12 @@
                 "is-utf8": "^0.2.0"
             }
         },
+        "strip-bom-string": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+            "integrity": "sha1-5SEekiQ2n7uB1jOi8ABE3IztrZI=",
+            "dev": true
+        },
         "strip-eof": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
@@ -9612,6 +9799,16 @@
             "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
             "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
             "dev": true
+        },
+        "timers-ext": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.7.tgz",
+            "integrity": "sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==",
+            "dev": true,
+            "requires": {
+                "es5-ext": "~0.10.46",
+                "next-tick": "1"
+            }
         },
         "tmpl": {
             "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -37,14 +37,15 @@
         "coveralls": "^3.1.0",
         "gulp": "^4.0.2",
         "gulp-cli": "^2.3.0",
+        "gulp-sourcemaps": "^2.6.5",
         "gulp-typescript": "^5.0.1",
         "jest": "^26.4.2",
         "jest-extended": "^0.11.5",
+        "nodemon": "^2.0.4",
         "supertest": "^4.0.2",
         "ts-jest": "^26.3.0",
         "ts-node": "^9.0.0",
-        "typescript": "^4.0.2",
-        "nodemon": "^2.0.4"
+        "typescript": "^4.0.2"
     },
     "dependencies": {
         "body-parser": "^1.19.0",


### PR DESCRIPTION
En travaillant sur un laboratoire utilisant ce squelette, je me suis rendu compte que ce serait utile d'être en mesure de déboguer le projet en ajoutant des points d'arrêt sur les fichiers TypeScript. J'ai donc implémenté une solution qui me permettait de faire exactement ça dans mon projet.

Je me suis dit que ce serait bien de partager ma solution avec les autres étudiants, d'où la pull request.

Le code de configuration contenu dans cette pull request permet donc, lorsqu'un débogueur est attaché à une instance en cours d’exécution, d'utiliser des points d'arrêt sur les fichiers TypeScript du back-end. 

Cette solution a été testé avec les IDEs VSCode et WebStorm en utilisant leur débogueur respectif.