### PR TITLE
Enable esModuleInterop

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -1,9 +1,9 @@
 import * as path from 'path';
-import * as express from 'express';
-import * as logger from 'morgan';
+import express from 'express';
+import logger from 'morgan';
 import * as bodyParser from 'body-parser';
-import * as flash from 'node-twinkle';
-import * as ExpressSession from 'express-session';
+import flash from 'node-twinkle';
+import ExpressSession from 'express-session';
 
 import { jeuRoutes } from './routes/JeuRouter';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import * as http from 'http';
-import * as debug from 'debug';
+import debug from 'debug';
 
 import App from './App';
 

--- a/src/routes/JeuRouter.ts
+++ b/src/routes/JeuRouter.ts
@@ -1,5 +1,5 @@
 import { Router, Request, Response, NextFunction } from 'express';
-import * as flash from 'node-twinkle';
+import flash from 'node-twinkle';
 
 import { JeuDeDes } from '../core/JeuDeDes';
 import { InvalidParameterError } from '../core/errors/InvalidParameterError';

--- a/test/bonjourMonde.test.ts
+++ b/test/bonjourMonde.test.ts
@@ -1,4 +1,4 @@
-import * as supertest from "supertest";
+import supertest from 'supertest';
 import 'jest-extended';
 import app from '../src/App';
 

--- a/test/demarrerJeu.test.ts
+++ b/test/demarrerJeu.test.ts
@@ -1,4 +1,4 @@
-import * as supertest from "supertest";
+import supertest from 'supertest';
 import 'jest-extended';
 import app from '../src/App';
 

--- a/test/getJoueurs.test.ts
+++ b/test/getJoueurs.test.ts
@@ -1,4 +1,4 @@
-import * as supertest from "supertest";
+import supertest from 'supertest';
 import 'jest-extended';
 import app from '../src/App';
 

--- a/test/jouer.test.ts
+++ b/test/jouer.test.ts
@@ -1,4 +1,4 @@
-import * as supertest from "supertest";
+import supertest from 'supertest';
 import 'jest-extended';
 import app from '../src/App';
 

--- a/test/terminerJeu.test.ts
+++ b/test/terminerJeu.test.ts
@@ -1,4 +1,4 @@
-import * as supertest from "supertest";
+import supertest from 'supertest';
 import 'jest-extended';
 import app from '../src/App';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,8 @@
   "compilerOptions": {
     "target": "es6",
     "module": "commonjs",
-    "outDir": "dist"
+    "outDir": "dist",
+    "esModuleInterop": true,
   },
   "include": [
     "src/**/*.ts",


### PR DESCRIPTION
Les librairies ne sont pas toutes accurate sur la spécification des modules ES6.
Cette option permet de fixer les problème dans le code transpilé de TypeScript.
Ça permet également d'uniformisé les imports entre les librairies.

Certain module n'ont pas été remplacé pour éviter les conflits entre les différentes pull request.