### PR TITLE
Utiliser une classe abstraite pour regrouper les erreurs personnalisées

### DIFF
--- a/src/core/errors/AbstractError.ts
+++ b/src/core/errors/AbstractError.ts
@@ -1,0 +1,11 @@
+export default abstract class AbstractError extends Error {
+    /**
+     * Donne le code HTTP.
+     * https://fr.wikipedia.org/wiki/Liste_des_codes_HTTP
+     */
+    abstract get code(): number;
+
+    constructor(message: string) {
+        super(message);
+    }
+}

--- a/src/core/errors/AlreadyExistsError.ts
+++ b/src/core/errors/AlreadyExistsError.ts
@@ -1,8 +1,8 @@
-import { CustomError } from "./CustomError";
+import AbstractError from "./AbstractError";
 
 /**
  * @see Applying UML and Patterns, Chapter A35/F30
  */
-export class AlreadyExistsError extends CustomError {
+export class AlreadyExistsError extends AbstractError {
     public readonly code = 400;
 }

--- a/src/core/errors/AlreadyExistsError.ts
+++ b/src/core/errors/AlreadyExistsError.ts
@@ -1,14 +1,8 @@
+import { CustomError } from "./CustomError";
+
 /**
  * @see Applying UML and Patterns, Chapter A35/F30
  */
-export class AlreadyExistsError extends Error {
-    private _code: number = 400;
-
-    constructor(message: string) {
-        super(message);
-    }
-
-    get code() {
-        return this._code;
-    }
+export class AlreadyExistsError extends CustomError {
+    public readonly code = 400;
 }

--- a/src/core/errors/CustomError.ts
+++ b/src/core/errors/CustomError.ts
@@ -1,7 +1,0 @@
-export abstract class CustomError extends Error {
-    abstract get code(): number;
-
-    constructor(message: string) {
-        super(message);
-    }
-}

--- a/src/core/errors/CustomError.ts
+++ b/src/core/errors/CustomError.ts
@@ -1,0 +1,7 @@
+export abstract class CustomError extends Error {
+    abstract get code(): number;
+
+    constructor(message: string) {
+        super(message);
+    }
+}

--- a/src/core/errors/InvalidParameterError.ts
+++ b/src/core/errors/InvalidParameterError.ts
@@ -1,14 +1,8 @@
+import { CustomError } from "./CustomError";
+
 /**
  * @see Applying UML and Patterns, Chapter A35/F30
  */
-export class InvalidParameterError extends Error {
-    private _code: number = 400;
-
-    constructor(message: string) {
-        super(message);
-    }
-
-    get code() {
-        return this._code;
-    }
+export class InvalidParameterError extends CustomError {
+    public readonly code = 400;
 }

--- a/src/core/errors/InvalidParameterError.ts
+++ b/src/core/errors/InvalidParameterError.ts
@@ -1,8 +1,9 @@
-import { CustomError } from "./CustomError";
+import AbstractError from "./AbstractError";
+
 
 /**
  * @see Applying UML and Patterns, Chapter A35/F30
  */
-export class InvalidParameterError extends CustomError {
+export class InvalidParameterError extends AbstractError {
     public readonly code = 400;
 }

--- a/src/core/errors/NotFoundError.ts
+++ b/src/core/errors/NotFoundError.ts
@@ -1,8 +1,8 @@
-import { CustomError } from "./CustomError";
+import AbstractError from "./AbstractError";
 
 /**
  * @see Applying UML and Patterns, Chapter A35/F30
  */
-export class NotFoundError extends CustomError {
+export class NotFoundError extends AbstractError {
     public readonly code = 404;
 }

--- a/src/core/errors/NotFoundError.ts
+++ b/src/core/errors/NotFoundError.ts
@@ -1,14 +1,8 @@
+import { CustomError } from "./CustomError";
+
 /**
  * @see Applying UML and Patterns, Chapter A35/F30
  */
-export class NotFoundError extends Error {
-    private _code: number = 404;
-
-    constructor(message: string) {
-        super(message);
-    }
-
-    get code() {
-        return this._code;
-    }
+export class NotFoundError extends CustomError {
+    public readonly code = 404;
 }


### PR DESCRIPTION
C'est pour l'issues #84.