### PR TITLE
mlc: interpreter le code 503 comme étant actif

### DIFF
--- a/.github/workflows/markdownlinks.yml
+++ b/.github/workflows/markdownlinks.yml
@@ -21,8 +21,10 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Runs a single command using the runners shell
       - name: markdown-link-check
-        uses: gaurav-nelson/github-action-markdown-link-check@1.0.13
+        uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          config-file: '.mlc_config.json'

--- a/.mlc_config.json
+++ b/.mlc_config.json
@@ -1,0 +1,3 @@
+{
+  "aliveStatusCode": [503, 200]
+}

--- a/.mlc_config.json
+++ b/.mlc_config.json
@@ -1,3 +1,3 @@
 {
-  "aliveStatusCode": [503, 200]
+  "aliveStatusCodes": [503, 200]
 }

--- a/docs/Squelette.md
+++ b/docs/Squelette.md
@@ -4,6 +4,7 @@
 
 Ce squelette est proposé pour commencer les projets en LOG210. Il possède les qualités suivantes:
 
+<!-- markdown-link-check-disable -->
 - il est simple pour les débutants en LOG210
   - il n'y a pas de framework pour le front-end ni pour la persistance, mais ça n'empêche pas d'ajouter ces dimensions.
   - il est seulement [REST niveau 1](https://restfulapi.net/richardson-maturity-model/#level-two), mais ça n'empêche pas de modifier l'API pour qu'il soit [REST niveau 3](https://restfulapi.net/richardson-maturity-model/#level-three).
@@ -12,6 +13,7 @@ Ce squelette est proposé pour commencer les projets en LOG210. Il possède les 
 - il fait une séparation entre les couches présentation et domaine, selon la méthodologie de conception du cours LOG210 (Larman)
 - il fournit une structure (en Bootstrap et Pug) permettant de gérer les connexions d'utilisateur et les vues selon le type d'utilisateur
 - il fonctionne sur Windows 10 (et probablement d'autres systèmes d'exploitation avec Node)
+<!-- markdown-link-check-enable -->
 
 ## D'où vient l'idée de base pour ce squelette?
 

--- a/docs/Squelette.md
+++ b/docs/Squelette.md
@@ -4,7 +4,6 @@
 
 Ce squelette est proposé pour commencer les projets en LOG210. Il possède les qualités suivantes:
 
-<!-- markdown-link-check-disable -->
 - il est simple pour les débutants en LOG210
   - il n'y a pas de framework pour le front-end ni pour la persistance, mais ça n'empêche pas d'ajouter ces dimensions.
   - il est seulement [REST niveau 1](https://restfulapi.net/richardson-maturity-model/#level-two), mais ça n'empêche pas de modifier l'API pour qu'il soit [REST niveau 3](https://restfulapi.net/richardson-maturity-model/#level-three).
@@ -13,7 +12,6 @@ Ce squelette est proposé pour commencer les projets en LOG210. Il possède les 
 - il fait une séparation entre les couches présentation et domaine, selon la méthodologie de conception du cours LOG210 (Larman)
 - il fournit une structure (en Bootstrap et Pug) permettant de gérer les connexions d'utilisateur et les vues selon le type d'utilisateur
 - il fonctionne sur Windows 10 (et probablement d'autres systèmes d'exploitation avec Node)
-<!-- markdown-link-check-enable -->
 
 ## D'où vient l'idée de base pour ce squelette?
 


### PR DESCRIPTION
Le lien donne une erreur 503 par moment, pour évité que l'action github échoue ajoutons le code 503 comme étant un code actif.
Fix #120 